### PR TITLE
fix: add missing babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elephant-healthcare/crud-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A microservice boilerplate",
   "main": "lib/index.js",
   "scripts": {
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@hapi/hapi": "17.9.0",
+    "babel-runtime": "^6.26.0",
     "convict": "4.3.1",
     "dotenv": "6.0.0",
     "good": "8.1.1",


### PR DESCRIPTION
This caused issues when adding @elephant-healthcare/crud-api as a dependency to stock-api.

Quick fix in stock:
https://github.com/elephant-healthcare/primary-care-pilot/pull/2484

Thread: 
https://elephant-healthcare.slack.com/archives/C013FH33CMV/p1599735563024900

@jwhenshaw I'm not really sure what the state of this repo is. I've not published anything to npm yet, will wait for you to confirm what needs doing.